### PR TITLE
fix(infinite-loop): Rebased commit gets a different sha1

### DIFF
--- a/github/api.js
+++ b/github/api.js
@@ -57,6 +57,13 @@ module.exports = function(credentials, owner, repo) {
       }
 
       return pageStreamCallback(index + 1)
+          .flatMap(function (commits) {
+            if (commits.length == 0) {
+              paginationNeeded = false;
+            }
+            return commits;
+          })
+        .flatMap(Bacon.fromArray)
         .doAction(function(item) {
           if (stopCondition(item)) {
             paginationNeeded = false;
@@ -87,8 +94,7 @@ module.exports = function(credentials, owner, repo) {
       };
 
       return Bacon
-        .fromNodeCallback(github.pullRequests.getAll, requestParams)
-        .flatMap(Bacon.fromArray);
+        .fromNodeCallback(github.pullRequests.getAll, requestParams);
     }
 
     function stopWhenSinceIsReached(pullRequest) {
@@ -123,8 +129,7 @@ module.exports = function(credentials, owner, repo) {
       }
 
       return Bacon
-        .fromNodeCallback(github.repos.getCommits, requestParams)
-        .flatMap(Bacon.fromArray);
+        .fromNodeCallback(github.repos.getCommits, requestParams);
     }
 
     var stopWhenSinceIsReached;


### PR DESCRIPTION
When a commit is rebased, git create a new sha1, but github keep a reference to the old one (see `GET /repos/:owner/:repo/commits`).

When starting github-changelog by using a rebased commit as limit, the module enter in an infinite loop, because it keeps calling the `pageOfCommits` function until it find the limiting sha1 (the old one, not existing anymore in the commits list).

This fix is just a work around and does not really solve this issue. Github is smart enough to stop returning commits when the limiting sha1 or his alias is reached.
