### PR TITLE
Fix jira api errors handling

### DIFF
--- a/github/helper/jira/index.js
+++ b/github/helper/jira/index.js
@@ -26,7 +26,7 @@ module.exports = function(jira) {
               return commit;
             })
             .catch(function (error) {
-              console.error(error);
+              console.error('[Jira] API Error : ' + error);
               commit.jira = null;
 
               return commit;

--- a/github/helper/jira/index.js
+++ b/github/helper/jira/index.js
@@ -2,7 +2,7 @@
 
 module.exports = function(jira) {
   var parseTicketKeyFromTitle = function(string) {
-    var matches = /^([A-Z]{2,3}-\d+)/.exec(string);
+    var matches = /^([A-Z]+-\d+)/.exec(string);
 
     if (matches === null) {
       return null;
@@ -20,8 +20,14 @@ module.exports = function(jira) {
           jira
             .api
             .findIssue(key)
-            .then(function(issue) {
+            .then(function (issue) {
               commit.jira = issue;
+
+              return commit;
+            })
+            .catch(function (error) {
+              console.error(error);
+              commit.jira = null;
 
               return commit;
             })


### PR DESCRIPTION
Whenever Jira API calls fail, we are not currently catching the errors, therefore, the commits containing jira matches are discarded, and the changelog generated is wrong.

This will allow us to still have a correct changelog even when Jira is down.

I also changed the match regex, I can remove that change if you wish.
